### PR TITLE
Add GPU-enabled XGBoost / LightGBM / CatBoost entries to model registry

### DIFF
--- a/src/automl_engine/common/constants/algorithms.py
+++ b/src/automl_engine/common/constants/algorithms.py
@@ -4,6 +4,8 @@ AutoML 実行時に使用可能な分類モデルを辞書形式で定義する�
 
 from __future__ import annotations
 
+from catboost import CatBoostClassifier, CatBoostRegressor
+from lightgbm import LGBMClassifier, LGBMRegressor
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 from sklearn.linear_model import (
     ElasticNet,
@@ -14,6 +16,7 @@ from sklearn.linear_model import (
 )
 from sklearn.naive_bayes import GaussianNB
 from sklearn.svm import SVC, SVR
+from xgboost import XGBClassifier, XGBRegressor
 
 # 分類モデル定義レジストリ。
 CLASSIFICATION_MODEL_REGISTRY = {
@@ -101,6 +104,42 @@ CLASSIFICATION_MODEL_REGISTRY = {
                     "high": 1e-6,
                 },
             },
+        },
+    },
+    "xgb": {
+        "label": "XGBoost Classifier",
+        "estimator_cls": XGBClassifier,
+        "init_params": {
+            "tree_method": "gpu_hist",
+        },
+        "fit_params": {},
+        "search_space": {
+            "grid": {},
+            "optuna": {},
+        },
+    },
+    "lgbm": {
+        "label": "LightGBM Classifier",
+        "estimator_cls": LGBMClassifier,
+        "init_params": {
+            "device_type": "gpu",
+        },
+        "fit_params": {},
+        "search_space": {
+            "grid": {},
+            "optuna": {},
+        },
+    },
+    "catboost": {
+        "label": "CatBoost Classifier",
+        "estimator_cls": CatBoostClassifier,
+        "init_params": {
+            "task_type": "GPU",
+        },
+        "fit_params": {},
+        "search_space": {
+            "grid": {},
+            "optuna": {},
         },
     },
 }
@@ -253,6 +292,42 @@ REGRESSION_MODEL_REGISTRY = {
                     "choices": ["sqrt", "log2", None],
                 },
             },
+        },
+    },
+    "xgb": {
+        "label": "XGBoost Regressor",
+        "estimator_cls": XGBRegressor,
+        "init_params": {
+            "tree_method": "gpu_hist",
+        },
+        "fit_params": {},
+        "search_space": {
+            "grid": {},
+            "optuna": {},
+        },
+    },
+    "lgbm": {
+        "label": "LightGBM Regressor",
+        "estimator_cls": LGBMRegressor,
+        "init_params": {
+            "device_type": "gpu",
+        },
+        "fit_params": {},
+        "search_space": {
+            "grid": {},
+            "optuna": {},
+        },
+    },
+    "catboost": {
+        "label": "CatBoost Regressor",
+        "estimator_cls": CatBoostRegressor,
+        "init_params": {
+            "task_type": "GPU",
+        },
+        "fit_params": {},
+        "search_space": {
+            "grid": {},
+            "optuna": {},
         },
     },
 }


### PR DESCRIPTION
### Motivation
- Enable GPU-accelerated training for common gradient boosting frameworks by providing sensible GPU defaults in the model registry.
- Provide out-of-the-box entries so these models can be selected by the AutoML engine similarly to existing scikit-learn models.

### Description
- Added imports for `XGBClassifier`/`XGBRegressor`, `LGBMClassifier`/`LGBMRegressor`, and `CatBoostClassifier`/`CatBoostRegressor` in `src/automl_engine/common/constants/algorithms.py`.
- Added `xgb`, `lgbm`, and `catboost` entries to `CLASSIFICATION_MODEL_REGISTRY` with `init_params` set to `{"tree_method": "gpu_hist"}`, `{"device_type": "gpu"}`, and `{"task_type": "GPU"}` respectively.
- Added corresponding `xgb`, `lgbm`, and `catboost` entries to `REGRESSION_MODEL_REGISTRY` with the same GPU-oriented `init_params` for regressors.
- Each new entry includes empty `fit_params` and placeholder `search_space` keys to match existing registry structure.

### Testing
- No automated tests were executed for this change.
- Static project configuration and test suite were not modified by this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952a57b274c8330893e6d1b7d666700)